### PR TITLE
Dynamic sampling with constant averaging graph

### DIFF
--- a/src/decentralizepy/node/PeerSamplerDynamic.py
+++ b/src/decentralizepy/node/PeerSamplerDynamic.py
@@ -84,7 +84,7 @@ class PeerSamplerDynamic(PeerSampler):
         """
 
         self.iteration = -1
-        self.graphs = []
+        self.graphs: list[Graph] = []
 
         nodeConfigs = config["NODE"]
         self.graph_degree = nodeConfigs["graph_degree"]

--- a/src/decentralizepy/node/PeerSamplerDynamicMultipleAvgRounds.py
+++ b/src/decentralizepy/node/PeerSamplerDynamicMultipleAvgRounds.py
@@ -16,7 +16,9 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
 
     def get_neighbors(self, node, iteration=None, averaging_round=0):
         # logging.debug(f"Node : {node}, {iteration}, {averaging_round} ")
-        if self.static_avgrounds:
+        if (
+            not self.dynamic_avgrounds
+        ):  # We only want the same graph, super() already handles the job, but not the API
             return super().get_neighbors(node, iteration=iteration)
         if iteration is not None:
             current_seed = (
@@ -80,10 +82,10 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
         logging.info("Saving graphs:")
         graph_log_dir = f"{self.log_dir}/graphs/"
         os.mkdir(graph_log_dir)
-        if self.static_avgrounds:  # If we have dynamicity only between GD
+        if not self.dynamic_avgrounds:  # If we have dynamicity only between GD
             for iteration, graph in enumerate(self.graphs):
                 graph.write_graph_to_file(f"{graph_log_dir}{iteration}")
-        else:  # When we randomize each graph
+        else:  # When we randomize each graph between averaging rounds.
             for iteration, iteration_graph_list in enumerate(self.graphs_lists):
                 for averaging_round, graph in enumerate(iteration_graph_list):
                     graph.write_graph_to_file(
@@ -102,7 +104,7 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
         averaging_rounds=1,
         log_dir=".",
         log_level=logging.INFO,
-        static_avgrounds=True,
+        dynamic_avgrounds=False,
         *args,
     ):
         """
@@ -138,6 +140,9 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
             Logging directory
         log_level : logging.Level
             One of DEBUG, INFO, WARNING, ERROR, CRITICAL
+        dynamic_avgrounds : bool, default False
+            If true, randomize between each averaging round, if False randomize the graph only
+            between gradient descent steps.
         args : optional
             Other arguments
 
@@ -146,8 +151,8 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
         self.iteration = -1
         self.averaging_round = 0
 
-        self.static_avgrounds = static_avgrounds
-        logging.debug("static_avgrounds set to %s", self.static_avgrounds)
+        self.dynamic_avgrounds = dynamic_avgrounds
+        logging.debug("dynamic_avgrounds set to %s", self.dynamic_avgrounds)
 
         self.total_averaging_rounds = averaging_rounds
 

--- a/src/decentralizepy/node/PeerSamplerDynamicMultipleAvgRounds.py
+++ b/src/decentralizepy/node/PeerSamplerDynamicMultipleAvgRounds.py
@@ -80,11 +80,15 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
         logging.info("Saving graphs:")
         graph_log_dir = f"{self.log_dir}/graphs/"
         os.mkdir(graph_log_dir)
-        for iteration, iteration_graph_list in enumerate(self.graphs_lists):
-            for averaging_round, graph in enumerate(iteration_graph_list):
-                graph.write_graph_to_file(
-                    f"{graph_log_dir}{iteration}_{averaging_round}"
-                )
+        if self.static_avgrounds:  # If we have dynamicity only between GD
+            for iteration, graph in enumerate(self.graphs):
+                graph.write_graph_to_file(f"{graph_log_dir}{iteration}")
+        else:  # When we randomize each graph
+            for iteration, iteration_graph_list in enumerate(self.graphs_lists):
+                for averaging_round, graph in enumerate(iteration_graph_list):
+                    graph.write_graph_to_file(
+                        f"{graph_log_dir}{iteration}_{averaging_round}"
+                    )
         logging.info("Saved graphs")
 
     def __init__(

--- a/src/decentralizepy/node/PeerSamplerDynamicMultipleAvgRounds.py
+++ b/src/decentralizepy/node/PeerSamplerDynamicMultipleAvgRounds.py
@@ -16,6 +16,8 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
 
     def get_neighbors(self, node, iteration=None, averaging_round=0):
         # logging.debug(f"Node : {node}, {iteration}, {averaging_round} ")
+        if self.static_avgrounds:
+            return super().get_neighbors(node, iteration=iteration)
         if iteration is not None:
             current_seed = (
                 self.random_seed * 100000 + 10000000 * iteration + averaging_round
@@ -78,9 +80,11 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
         logging.info("Saving graphs:")
         graph_log_dir = f"{self.log_dir}/graphs/"
         os.mkdir(graph_log_dir)
-        for iteration,iteration_graph_list in enumerate(self.graphs):
+        for iteration, iteration_graph_list in enumerate(self.graphs):
             for averaging_round, graph in enumerate(iteration_graph_list):
-                graph.write_graph_to_file(f"{graph_log_dir}{iteration}_{averaging_round}")
+                graph.write_graph_to_file(
+                    f"{graph_log_dir}{iteration}_{averaging_round}"
+                )
         logging.info("Saved graphs")
 
     def __init__(
@@ -94,6 +98,7 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
         averaging_rounds=1,
         log_dir=".",
         log_level=logging.INFO,
+        static_avgrounds=True,
         *args,
     ):
         """
@@ -137,6 +142,9 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
         self.iteration = -1
         self.averaging_round = 0
 
+        self.static_avgrounds = static_avgrounds
+        logging.debug("static_avgrounds set to %s", self.static_avgrounds)
+
         self.total_averaging_rounds = averaging_rounds
 
         self.graphs = []
@@ -153,7 +161,7 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
             iterations=iterations,
             log_dir=log_dir,
             log_level=log_level,
-            *args,
+            # *args,
         )
 
         self.run()

--- a/src/decentralizepy/node/PeerSamplerDynamicMultipleAvgRounds.py
+++ b/src/decentralizepy/node/PeerSamplerDynamicMultipleAvgRounds.py
@@ -34,7 +34,7 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
                 self.iteration = iteration
                 self.averaging_round = 0
                 # logging.debug(f"n_procs : {self.graph.n_procs}, degree :{self.graph_degree}")
-                self.graphs.append(
+                self.graphs_lists.append(
                     [Regular(self.graph.n_procs, self.graph_degree, seed=current_seed)]
                 )
             elif iteration == self.iteration and averaging_round > self.averaging_round:
@@ -46,11 +46,11 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
                     averaging_round == self.averaging_round + 1
                 ), f"Expected to be averaging round {self.averaging_round + 1}, got {averaging_round}"
                 self.averaging_round = averaging_round
-                self.graphs[iteration].append(
+                self.graphs_lists[iteration].append(
                     Regular(self.graph.n_procs, self.graph_degree, seed=current_seed)
                 )
 
-            return self.graphs[iteration][averaging_round].neighbors(node)
+            return self.graphs_lists[iteration][averaging_round].neighbors(node)
         else:
             return self.graph.neighbors(node)
 
@@ -80,7 +80,7 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
         logging.info("Saving graphs:")
         graph_log_dir = f"{self.log_dir}/graphs/"
         os.mkdir(graph_log_dir)
-        for iteration, iteration_graph_list in enumerate(self.graphs):
+        for iteration, iteration_graph_list in enumerate(self.graphs_lists):
             for averaging_round, graph in enumerate(iteration_graph_list):
                 graph.write_graph_to_file(
                     f"{graph_log_dir}{iteration}_{averaging_round}"
@@ -147,7 +147,8 @@ class PeerSamplerDynamicMultipleAvgRounds(PeerSamplerDynamic):
 
         self.total_averaging_rounds = averaging_rounds
 
-        self.graphs = []
+        self.graphs: list[Graph] = []
+        self.graphs_lists: list[list[Graph]] = []
 
         node_configs = config["NODE"]
         self.graph_degree = node_configs["graph_degree"]


### PR DESCRIPTION
Implementation of #9 - a new boolean parameter is provided to the PeerSampler `dynamic_avgrounds`. 
The default behavior was changed to mimic Muffliato's behavior, as they require multiple averaging rounds.